### PR TITLE
fix: nullException on Source as Uri casting

### DIFF
--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView.Uno.WinUI.csproj
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView.Uno.WinUI.csproj
@@ -25,7 +25,7 @@
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="4.9.0-dev.1113" />
+    <PackageReference Include="Uno.WinUI" Version="4.9.17" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Logging" Version="4.0.1" />

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -164,7 +164,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Information))
 		{
-			_logger.LogInformation($"The navigation to uri '{SourceUri.AbsoluteUri}' has succeeded.");
+			_logger.LogInformation($"The navigation to uri has succeeded.");
 		}
 	}
 
@@ -176,7 +176,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Error))
 		{
-			_logger.LogError($"The navigation to uri '{SourceUri.AbsoluteUri}' failed due to '{args?.WebErrorStatus}'.");
+			_logger.LogError($"The navigation to uri failed due to '{args?.WebErrorStatus}'.");
 		}
 	}
 
@@ -184,14 +184,14 @@ public partial class AsyncWebView : Control
 	{
 		if (_logger.IsEnabled(LogLevel.Debug))
 		{
-			_logger.LogDebug($"Handling the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
+			_logger.LogDebug($"Handling the completed navigation to uri.");
 		}
 
 		if (CompletionCommand != null)
 		{
 			// We cannot use WebViewNavigationCompletedEventArgs directly, as it must be called from the UI Thread on Windows
 			// The WebErrorStatus field is not provided, as it uses a different namespace in Uno and Windows.
-			var commandArgs = new CompletionCommandArgs(this, args.IsSuccess, SourceUri);
+			var commandArgs = new CompletionCommandArgs(this, args.IsSuccess, SourceUri ?? null);
 
 			if (CompletionCommand.CanExecute(commandArgs))
 			{
@@ -200,7 +200,7 @@ public partial class AsyncWebView : Control
 
 			if (_logger.IsEnabled(LogLevel.Information))
 			{
-				_logger.LogInformation($"Handled the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
+				_logger.LogInformation($"Handled the completed navigation to uri.");
 			}
 		}
 	}
@@ -426,7 +426,7 @@ public partial class AsyncWebView : Control
 		}
 
 		Uri uri = new Uri(args.Uri);
-		var absoluteUri = (Source as Uri).AbsoluteUri;
+		string absoluteUri = uri.AbsoluteUri;
 
 		// We always ignore starting a navigation to about:blank.
 		if (absoluteUri.Equals(_blankPageUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -150,6 +150,8 @@ public partial class AsyncWebView : Control
 
 	protected virtual bool OnNavigationStarting(NavigationStartingEventArgs args)
 	{
+		SourceUri = new Uri(args?.Uri);
+
 		if (_logger.IsEnabled(LogLevel.Trace))
 		{
 			_logger.Trace($"Navigation to uri '{args?.Uri}' is starting.");
@@ -164,7 +166,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Information))
 		{
-			_logger.LogInformation($"The navigation to uri has succeeded.");
+			_logger.LogInformation($"The navigation to uri '{SourceUri.AbsoluteUri}' has succeeded.");
 		}
 	}
 
@@ -176,7 +178,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Error))
 		{
-			_logger.LogError($"The navigation to uri failed due to '{args?.WebErrorStatus}'.");
+			_logger.LogError($"The navigation to uri '{SourceUri.AbsoluteUri}' failed due to '{args?.WebErrorStatus}'.");
 		}
 	}
 
@@ -184,7 +186,7 @@ public partial class AsyncWebView : Control
 	{
 		if (_logger.IsEnabled(LogLevel.Debug))
 		{
-			_logger.LogDebug($"Handling the completed navigation to uri.");
+			_logger.LogDebug($"Handling the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
 		}
 
 		if (CompletionCommand != null)
@@ -200,7 +202,7 @@ public partial class AsyncWebView : Control
 
 			if (_logger.IsEnabled(LogLevel.Information))
 			{
-				_logger.LogInformation($"Handled the completed navigation to uri.");
+				_logger.LogInformation($"Handled the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
 			}
 		}
 	}

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -150,11 +150,9 @@ public partial class AsyncWebView : Control
 
 	protected virtual bool OnNavigationStarting(NavigationStartingEventArgs args)
 	{
-		SourceUri = new Uri(args?.Uri);
-
 		if (_logger.IsEnabled(LogLevel.Trace))
 		{
-			_logger.Trace($"Navigation to uri '{args?.Uri}' is starting.");
+			_logger.Trace($"Navigation '{args?.NavigationId}', to uri '{args?.Uri}', is starting.");
 		}
 
 		return true;
@@ -166,7 +164,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Information))
 		{
-			_logger.LogInformation($"The navigation to uri '{SourceUri.AbsoluteUri}' has succeeded.");
+			_logger.LogInformation($"Navigation '{args?.NavigationId}' has succeeded.");
 		}
 	}
 
@@ -178,7 +176,7 @@ public partial class AsyncWebView : Control
 
 		if (_logger.IsEnabled(LogLevel.Error))
 		{
-			_logger.LogError($"The navigation to uri '{SourceUri.AbsoluteUri}' failed due to '{args?.WebErrorStatus}'.");
+			_logger.LogError($"Navigation '{args?.NavigationId}' on the AsyncWebView failed due to '{args?.WebErrorStatus}'.");
 		}
 	}
 
@@ -186,7 +184,7 @@ public partial class AsyncWebView : Control
 	{
 		if (_logger.IsEnabled(LogLevel.Debug))
 		{
-			_logger.LogDebug($"Handling the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
+			_logger.LogDebug($"Handling the completed navigation '{args?.NavigationId}'.");
 		}
 
 		if (CompletionCommand != null)
@@ -202,7 +200,7 @@ public partial class AsyncWebView : Control
 
 			if (_logger.IsEnabled(LogLevel.Information))
 			{
-				_logger.LogInformation($"Handled the completed navigation to uri '{SourceUri.AbsoluteUri}'.");
+				_logger.LogInformation($"Handled the completed navigation '{args?.NavigationId}'.");
 			}
 		}
 	}

--- a/src/AsyncWebView.Uno/AsyncWebView.Uno.csproj
+++ b/src/AsyncWebView.Uno/AsyncWebView.Uno.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
+		<LangVersion>10.0</LangVersion>
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
 		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/src/Shared/Helpers/CompletionCommandArgs.cs
+++ b/src/Shared/Helpers/CompletionCommandArgs.cs
@@ -18,7 +18,7 @@ namespace AsyncWebView
 		/// <param name="asyncWebView">Async Webview</param>
 		/// <param name="isSuccess">If the navigation completed with success</param>
 		/// <param name="uri">The destination Uri of the navigation, if any</param>
-		public CompletionCommandArgs(AsyncWebView asyncWebView, bool isSuccess, Uri uri)
+		public CompletionCommandArgs(AsyncWebView asyncWebView, bool isSuccess, Uri? uri) 
 		{
 			_asyncWebView = asyncWebView;
 
@@ -34,7 +34,7 @@ namespace AsyncWebView
 		/// <summary>
 		/// Gets the destination Uri of the navigation, if any.
 		/// </summary>
-		public Uri Uri { get; }
+		public Uri? Uri { get; }
 
 		/// <summary>
 		/// Invokes the secified javascript in the context of the currently loaded web page.


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

<!-- - Bug fix -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
In some cases, we get an exception on the Uri casting of Source to get the AbsoluteUri.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Using the Uri created from the starting event arguments to be consistent and remove the requirement of casting.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

