### PR TITLE
fix: Fixes exception when invalid URIs are used as source

### DIFF
--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -534,7 +534,7 @@ public partial class AsyncWebView : Control
 	{
 		var sourceUri = default(Uri);
 
-		if (Source is string source)
+		if (Source is string source && Uri.IsWellFormedUriString(source, UriKind.RelativeOrAbsolute))
 		{
 			sourceUri = new Uri(source);
 		}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
Handles malformed URIs during string parse

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
App might crash or fail when passing non-compliant URIs to the Source property.


## What is the new behavior?
App doesn't raise an exception when passing non-compliant URIs to the Source property.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [X] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

