### PR TITLE
fix: Prevent blank page after cancelling navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 (2025-06-19)
+- Fix blank page after cancelling navigation via `OnNavigationStarting`.
+
 ## 0.7.0 (2025-06-18)
 - Target .NET 8.
 - Added overridable method `OnNewWindowRequested` to support cancelling external navigations.

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.7.0
+next-version: 0.7.1
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -638,8 +638,9 @@ public partial class AsyncWebView : Control
 		_isLastErrorOnSource = !args.IsSuccess && _isUpdating;
 		_isUpdating = false;
 
-		if (args.IsSuccess)
+		if (args.IsSuccess || args.WebErrorStatus == CoreWebView2WebErrorStatus.OperationCanceled)
 		{
+			// We consider OperationCanceled as a successful navigation because we don't what to introduce a blank or error state when we simply return false in OnNavigationStarting.
 			OnNavigationSucceeded(args);
 		}
 		else


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

We can experience a blank screen after cancelling a navigation via `OnNavigationStarting`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

There is no blank screen after cancelling a navigation via `OnNavigationStarting`.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

