### PR TITLE
fix: infinite loading when using anchor navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.7.2 (2025-06-20)
+- Fix infinite loading when setting a source that is the same Uri with a new anchor.
+
 ## 0.7.1 (2025-06-19)
 - Fix blank page after cancelling navigation via `OnNavigationStarting`.
 

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 ﻿assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.7.1
+next-version: 0.7.2
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -254,12 +254,23 @@ public partial class AsyncWebView : Control
 		var sourceUri = source as Uri;
 		if (sourceUri != null)
 		{
-			_isUpdating = true;
+			// We need to check if the uri is the same because uris with the same base but different anchor are equal.
+			// When navigating to an anchor the WebView2 does not trigger any navigation event.
+			// For that reason we cannot set a loading state because we don't have a trigger to remove it later on.
+			if (sourceUri.Equals(_webView.Source))
+			{
+				NavigateToUri(sourceUri);
+				return;
+			}
+			else
+			{
+				_isUpdating = true;
 
-			UpdateVisualState(VisualStates.Loading);
-			NavigateToUri(sourceUri);
+				UpdateVisualState(VisualStates.Loading);
+				NavigateToUri(sourceUri);
 
-			return;
+				return;
+			}
 		}
 
 		var sourceHttpRequestMessage = source as HttpRequestMessage;
@@ -379,7 +390,8 @@ public partial class AsyncWebView : Control
 		_webView.NavigationStarting += OnNavigationgStartingEvent;
 		_webView.NavigationCompleted += OnNavigationCompletedEvent;
 		_webView.CoreProcessFailed += OnNavigationFailedEvent;
-		_ = _dispatcher.RunAsync(DispatcherQueuePriority.Normal, async () => {
+		_ = _dispatcher.RunAsync(DispatcherQueuePriority.Normal, async () =>
+		{
 
 			await _webView.EnsureCoreWebView2Async();
 			_webView.CoreWebView2.HistoryChanged += OnHistoryChangedEvent;


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix


## What is the current behavior?
The AsyncWebView loads infinitely when setting a Uri that would be the same as the old one but with an anchor at the end.


## What is the new behavior?
The AsyncWebView loads correctly when adding an anchor to the current Uri.


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

