### PR TITLE
fix: navigating to blank page dismiss error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.7.3 (2025-07-07)
+- Fix the navigate to blank page replacing error state by ready state.
+
 ## 0.7.2 (2025-06-20)
 - Fix infinite loading when setting a source that is the same Uri with a new anchor.
 

--- a/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno.WinUI/AsyncWebView/AsyncWebView.cs
@@ -168,6 +168,15 @@ public partial class AsyncWebView : Control
 
 	protected virtual void OnNavigationSucceeded(NavigationCompletedEventArgs args)
 	{
+		if (_webView?.Source?.OriginalString == "about:blank")
+		{
+			if (_logger.IsEnabled(LogLevel.Debug))
+			{
+				_logger.LogDebug("Navigation to about:blank — skipping Ready state.");
+			}
+			return;
+		}
+
 		UpdateVisualState(VisualStates.Ready);
 
 		if (_logger.IsEnabled(LogLevel.Information))


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
When a connectivity error occured, the AsyncWebView navigated to a blank page and replaced the Error state by a Ready state.


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The AsyncWebView keeps the error state when navigating to blank page.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

